### PR TITLE
feat: add r53 hosted zone stack

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -48,4 +48,5 @@ junit.xml
 .jsii
 tsconfig.json
 !/API.md
+.DS_Store
 !/.projenrc.js

--- a/.projenrc.js
+++ b/.projenrc.js
@@ -41,4 +41,5 @@ const project = new AwsCdkConstructLibrary({
   // devDeps: [],             /* Build dependencies for this module. */
   // packageName: undefined,  /* The "name" in package.json. */
 });
+project.gitignore.addPatterns('.DS_Store');
 project.synth();

--- a/API.md
+++ b/API.md
@@ -1092,6 +1092,7 @@ Any object.
 | <code><a href="#@smallcase/cdk-vpc-module.Network.property.natProvider">natProvider</a></code> | <code>aws-cdk-lib.aws_ec2.NatProvider</code> | *No description.* |
 | <code><a href="#@smallcase/cdk-vpc-module.Network.property.securityGroupOutputs">securityGroupOutputs</a></code> | <code>{[ key: string ]: aws-cdk-lib.aws_ec2.SecurityGroup}</code> | *No description.* |
 | <code><a href="#@smallcase/cdk-vpc-module.Network.property.vpc">vpc</a></code> | <code>aws-cdk-lib.aws_ec2.Vpc</code> | *No description.* |
+| <code><a href="#@smallcase/cdk-vpc-module.Network.property.hostedZoneStack">hostedZoneStack</a></code> | <code><a href="#@smallcase/cdk-vpc-module.HostedZoneStack">HostedZoneStack</a></code> | *No description.* |
 | <code><a href="#@smallcase/cdk-vpc-module.Network.property.natSubnets">natSubnets</a></code> | <code>aws-cdk-lib.aws_ec2.PublicSubnet[]</code> | *No description.* |
 | <code><a href="#@smallcase/cdk-vpc-module.Network.property.pbSubnets">pbSubnets</a></code> | <code>aws-cdk-lib.aws_ec2.PublicSubnet[]</code> | *No description.* |
 | <code><a href="#@smallcase/cdk-vpc-module.Network.property.pvSubnets">pvSubnets</a></code> | <code>aws-cdk-lib.aws_ec2.PrivateSubnet[]</code> | *No description.* |
@@ -1148,6 +1149,16 @@ public readonly vpc: Vpc;
 ```
 
 - *Type:* aws-cdk-lib.aws_ec2.Vpc
+
+---
+
+##### `hostedZoneStack`<sup>Optional</sup> <a name="hostedZoneStack" id="@smallcase/cdk-vpc-module.Network.property.hostedZoneStack"></a>
+
+```typescript
+public readonly hostedZoneStack: HostedZoneStack;
+```
+
+- *Type:* <a href="#@smallcase/cdk-vpc-module.HostedZoneStack">HostedZoneStack</a>
 
 ---
 
@@ -3203,6 +3214,7 @@ const vPCProps: VPCProps = { ... }
 | --- | --- | --- |
 | <code><a href="#@smallcase/cdk-vpc-module.VPCProps.property.subnets">subnets</a></code> | <code><a href="#@smallcase/cdk-vpc-module.ISubnetsProps">ISubnetsProps</a>[]</code> | *No description.* |
 | <code><a href="#@smallcase/cdk-vpc-module.VPCProps.property.vpc">vpc</a></code> | <code>aws-cdk-lib.aws_ec2.VpcProps</code> | *No description.* |
+| <code><a href="#@smallcase/cdk-vpc-module.VPCProps.property.hostedZones">hostedZones</a></code> | <code><a href="#@smallcase/cdk-vpc-module.HostedZoneConfig">HostedZoneConfig</a>[]</code> | *No description.* |
 | <code><a href="#@smallcase/cdk-vpc-module.VPCProps.property.natEipAllocationIds">natEipAllocationIds</a></code> | <code>string[]</code> | *No description.* |
 | <code><a href="#@smallcase/cdk-vpc-module.VPCProps.property.peeringConfigs">peeringConfigs</a></code> | <code>{[ key: string ]: <a href="#@smallcase/cdk-vpc-module.PeeringConfig">PeeringConfig</a>}</code> | *No description.* |
 | <code><a href="#@smallcase/cdk-vpc-module.VPCProps.property.useNestedStacks">useNestedStacks</a></code> | <code>boolean</code> | *No description.* |
@@ -3228,6 +3240,16 @@ public readonly vpc: VpcProps;
 ```
 
 - *Type:* aws-cdk-lib.aws_ec2.VpcProps
+
+---
+
+##### `hostedZones`<sup>Optional</sup> <a name="hostedZones" id="@smallcase/cdk-vpc-module.VPCProps.property.hostedZones"></a>
+
+```typescript
+public readonly hostedZones: HostedZoneConfig[];
+```
+
+- *Type:* <a href="#@smallcase/cdk-vpc-module.HostedZoneConfig">HostedZoneConfig</a>[]
 
 ---
 

--- a/API.md
+++ b/API.md
@@ -2279,7 +2279,9 @@ const hostedZoneConfig: HostedZoneConfig = { ... }
 | --- | --- | --- |
 | <code><a href="#@smallcase/cdk-vpc-module.HostedZoneConfig.property.publicZone">publicZone</a></code> | <code>boolean</code> | *No description.* |
 | <code><a href="#@smallcase/cdk-vpc-module.HostedZoneConfig.property.zoneName">zoneName</a></code> | <code>string</code> | *No description.* |
+| <code><a href="#@smallcase/cdk-vpc-module.HostedZoneConfig.property.certificateValidationZoneName">certificateValidationZoneName</a></code> | <code>string</code> | *No description.* |
 | <code><a href="#@smallcase/cdk-vpc-module.HostedZoneConfig.property.createAcmCertificate">createAcmCertificate</a></code> | <code>boolean</code> | *No description.* |
+| <code><a href="#@smallcase/cdk-vpc-module.HostedZoneConfig.property.tags">tags</a></code> | <code>{[ key: string ]: string}</code> | *No description.* |
 
 ---
 
@@ -2303,6 +2305,16 @@ public readonly zoneName: string;
 
 ---
 
+##### `certificateValidationZoneName`<sup>Optional</sup> <a name="certificateValidationZoneName" id="@smallcase/cdk-vpc-module.HostedZoneConfig.property.certificateValidationZoneName"></a>
+
+```typescript
+public readonly certificateValidationZoneName: string;
+```
+
+- *Type:* string
+
+---
+
 ##### `createAcmCertificate`<sup>Optional</sup> <a name="createAcmCertificate" id="@smallcase/cdk-vpc-module.HostedZoneConfig.property.createAcmCertificate"></a>
 
 ```typescript
@@ -2310,6 +2322,16 @@ public readonly createAcmCertificate: boolean;
 ```
 
 - *Type:* boolean
+
+---
+
+##### `tags`<sup>Optional</sup> <a name="tags" id="@smallcase/cdk-vpc-module.HostedZoneConfig.property.tags"></a>
+
+```typescript
+public readonly tags: {[ key: string ]: string};
+```
+
+- *Type:* {[ key: string ]: string}
 
 ---
 
@@ -2333,6 +2355,7 @@ const hostedZoneStackProps: HostedZoneStackProps = { ... }
 | <code><a href="#@smallcase/cdk-vpc-module.HostedZoneStackProps.property.removalPolicy">removalPolicy</a></code> | <code>aws-cdk-lib.RemovalPolicy</code> | Policy to apply when the nested stack is removed. |
 | <code><a href="#@smallcase/cdk-vpc-module.HostedZoneStackProps.property.timeout">timeout</a></code> | <code>aws-cdk-lib.Duration</code> | The length of time that CloudFormation waits for the nested stack to reach the CREATE_COMPLETE state. |
 | <code><a href="#@smallcase/cdk-vpc-module.HostedZoneStackProps.property.hostedZones">hostedZones</a></code> | <code><a href="#@smallcase/cdk-vpc-module.HostedZoneConfig">HostedZoneConfig</a>[]</code> | *No description.* |
+| <code><a href="#@smallcase/cdk-vpc-module.HostedZoneStackProps.property.hostedZoneTags">hostedZoneTags</a></code> | <code>{[ key: string ]: string}</code> | *No description.* |
 | <code><a href="#@smallcase/cdk-vpc-module.HostedZoneStackProps.property.vpc">vpc</a></code> | <code>aws-cdk-lib.aws_ec2.IVpc</code> | *No description.* |
 
 ---
@@ -2427,6 +2450,16 @@ public readonly hostedZones: HostedZoneConfig[];
 ```
 
 - *Type:* <a href="#@smallcase/cdk-vpc-module.HostedZoneConfig">HostedZoneConfig</a>[]
+
+---
+
+##### `hostedZoneTags`<sup>Optional</sup> <a name="hostedZoneTags" id="@smallcase/cdk-vpc-module.HostedZoneStackProps.property.hostedZoneTags"></a>
+
+```typescript
+public readonly hostedZoneTags: {[ key: string ]: string};
+```
+
+- *Type:* {[ key: string ]: string}
 
 ---
 
@@ -3215,6 +3248,7 @@ const vPCProps: VPCProps = { ... }
 | <code><a href="#@smallcase/cdk-vpc-module.VPCProps.property.subnets">subnets</a></code> | <code><a href="#@smallcase/cdk-vpc-module.ISubnetsProps">ISubnetsProps</a>[]</code> | *No description.* |
 | <code><a href="#@smallcase/cdk-vpc-module.VPCProps.property.vpc">vpc</a></code> | <code>aws-cdk-lib.aws_ec2.VpcProps</code> | *No description.* |
 | <code><a href="#@smallcase/cdk-vpc-module.VPCProps.property.hostedZones">hostedZones</a></code> | <code><a href="#@smallcase/cdk-vpc-module.HostedZoneConfig">HostedZoneConfig</a>[]</code> | *No description.* |
+| <code><a href="#@smallcase/cdk-vpc-module.VPCProps.property.hostedZoneTags">hostedZoneTags</a></code> | <code>{[ key: string ]: string}</code> | *No description.* |
 | <code><a href="#@smallcase/cdk-vpc-module.VPCProps.property.natEipAllocationIds">natEipAllocationIds</a></code> | <code>string[]</code> | *No description.* |
 | <code><a href="#@smallcase/cdk-vpc-module.VPCProps.property.peeringConfigs">peeringConfigs</a></code> | <code>{[ key: string ]: <a href="#@smallcase/cdk-vpc-module.PeeringConfig">PeeringConfig</a>}</code> | *No description.* |
 | <code><a href="#@smallcase/cdk-vpc-module.VPCProps.property.useNestedStacks">useNestedStacks</a></code> | <code>boolean</code> | *No description.* |
@@ -3250,6 +3284,16 @@ public readonly hostedZones: HostedZoneConfig[];
 ```
 
 - *Type:* <a href="#@smallcase/cdk-vpc-module.HostedZoneConfig">HostedZoneConfig</a>[]
+
+---
+
+##### `hostedZoneTags`<sup>Optional</sup> <a name="hostedZoneTags" id="@smallcase/cdk-vpc-module.VPCProps.property.hostedZoneTags"></a>
+
+```typescript
+public readonly hostedZoneTags: {[ key: string ]: string};
+```
+
+- *Type:* {[ key: string ]: string}
 
 ---
 

--- a/API.md
+++ b/API.md
@@ -2,6 +2,978 @@
 
 ## Constructs <a name="Constructs" id="Constructs"></a>
 
+### HostedZoneStack <a name="HostedZoneStack" id="@smallcase/cdk-vpc-module.HostedZoneStack"></a>
+
+#### Initializers <a name="Initializers" id="@smallcase/cdk-vpc-module.HostedZoneStack.Initializer"></a>
+
+```typescript
+import { HostedZoneStack } from '@smallcase/cdk-vpc-module'
+
+new HostedZoneStack(scope: Construct, id: string, props: HostedZoneStackProps)
+```
+
+| **Name** | **Type** | **Description** |
+| --- | --- | --- |
+| <code><a href="#@smallcase/cdk-vpc-module.HostedZoneStack.Initializer.parameter.scope">scope</a></code> | <code>constructs.Construct</code> | *No description.* |
+| <code><a href="#@smallcase/cdk-vpc-module.HostedZoneStack.Initializer.parameter.id">id</a></code> | <code>string</code> | *No description.* |
+| <code><a href="#@smallcase/cdk-vpc-module.HostedZoneStack.Initializer.parameter.props">props</a></code> | <code><a href="#@smallcase/cdk-vpc-module.HostedZoneStackProps">HostedZoneStackProps</a></code> | *No description.* |
+
+---
+
+##### `scope`<sup>Required</sup> <a name="scope" id="@smallcase/cdk-vpc-module.HostedZoneStack.Initializer.parameter.scope"></a>
+
+- *Type:* constructs.Construct
+
+---
+
+##### `id`<sup>Required</sup> <a name="id" id="@smallcase/cdk-vpc-module.HostedZoneStack.Initializer.parameter.id"></a>
+
+- *Type:* string
+
+---
+
+##### `props`<sup>Required</sup> <a name="props" id="@smallcase/cdk-vpc-module.HostedZoneStack.Initializer.parameter.props"></a>
+
+- *Type:* <a href="#@smallcase/cdk-vpc-module.HostedZoneStackProps">HostedZoneStackProps</a>
+
+---
+
+#### Methods <a name="Methods" id="Methods"></a>
+
+| **Name** | **Description** |
+| --- | --- |
+| <code><a href="#@smallcase/cdk-vpc-module.HostedZoneStack.toString">toString</a></code> | Returns a string representation of this construct. |
+| <code><a href="#@smallcase/cdk-vpc-module.HostedZoneStack.addDependency">addDependency</a></code> | Add a dependency between this stack and another stack. |
+| <code><a href="#@smallcase/cdk-vpc-module.HostedZoneStack.addMetadata">addMetadata</a></code> | Adds an arbitrary key-value pair, with information you want to record about the stack. |
+| <code><a href="#@smallcase/cdk-vpc-module.HostedZoneStack.addStackTag">addStackTag</a></code> | Configure a stack tag. |
+| <code><a href="#@smallcase/cdk-vpc-module.HostedZoneStack.addTransform">addTransform</a></code> | Add a Transform to this stack. A Transform is a macro that AWS CloudFormation uses to process your template. |
+| <code><a href="#@smallcase/cdk-vpc-module.HostedZoneStack.exportStringListValue">exportStringListValue</a></code> | Create a CloudFormation Export for a string list value. |
+| <code><a href="#@smallcase/cdk-vpc-module.HostedZoneStack.exportValue">exportValue</a></code> | Create a CloudFormation Export for a string value. |
+| <code><a href="#@smallcase/cdk-vpc-module.HostedZoneStack.formatArn">formatArn</a></code> | Creates an ARN from components. |
+| <code><a href="#@smallcase/cdk-vpc-module.HostedZoneStack.getLogicalId">getLogicalId</a></code> | Allocates a stack-unique CloudFormation-compatible logical identity for a specific resource. |
+| <code><a href="#@smallcase/cdk-vpc-module.HostedZoneStack.regionalFact">regionalFact</a></code> | Look up a fact value for the given fact for the region of this stack. |
+| <code><a href="#@smallcase/cdk-vpc-module.HostedZoneStack.removeStackTag">removeStackTag</a></code> | Remove a stack tag. |
+| <code><a href="#@smallcase/cdk-vpc-module.HostedZoneStack.renameLogicalId">renameLogicalId</a></code> | Rename a generated logical identities. |
+| <code><a href="#@smallcase/cdk-vpc-module.HostedZoneStack.reportMissingContextKey">reportMissingContextKey</a></code> | Indicate that a context key was expected. |
+| <code><a href="#@smallcase/cdk-vpc-module.HostedZoneStack.resolve">resolve</a></code> | Resolve a tokenized value in the context of the current stack. |
+| <code><a href="#@smallcase/cdk-vpc-module.HostedZoneStack.splitArn">splitArn</a></code> | Splits the provided ARN into its components. |
+| <code><a href="#@smallcase/cdk-vpc-module.HostedZoneStack.toJsonString">toJsonString</a></code> | Convert an object, potentially containing tokens, to a JSON string. |
+| <code><a href="#@smallcase/cdk-vpc-module.HostedZoneStack.toYamlString">toYamlString</a></code> | Convert an object, potentially containing tokens, to a YAML string. |
+| <code><a href="#@smallcase/cdk-vpc-module.HostedZoneStack.setParameter">setParameter</a></code> | Assign a value to one of the nested stack parameters. |
+
+---
+
+##### `toString` <a name="toString" id="@smallcase/cdk-vpc-module.HostedZoneStack.toString"></a>
+
+```typescript
+public toString(): string
+```
+
+Returns a string representation of this construct.
+
+##### `addDependency` <a name="addDependency" id="@smallcase/cdk-vpc-module.HostedZoneStack.addDependency"></a>
+
+```typescript
+public addDependency(target: Stack, reason?: string): void
+```
+
+Add a dependency between this stack and another stack.
+
+This can be used to define dependencies between any two stacks within an
+app, and also supports nested stacks.
+
+###### `target`<sup>Required</sup> <a name="target" id="@smallcase/cdk-vpc-module.HostedZoneStack.addDependency.parameter.target"></a>
+
+- *Type:* aws-cdk-lib.Stack
+
+---
+
+###### `reason`<sup>Optional</sup> <a name="reason" id="@smallcase/cdk-vpc-module.HostedZoneStack.addDependency.parameter.reason"></a>
+
+- *Type:* string
+
+---
+
+##### `addMetadata` <a name="addMetadata" id="@smallcase/cdk-vpc-module.HostedZoneStack.addMetadata"></a>
+
+```typescript
+public addMetadata(key: string, value: any): void
+```
+
+Adds an arbitrary key-value pair, with information you want to record about the stack.
+
+These get translated to the Metadata section of the generated template.
+
+> [https://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/metadata-section-structure.html](https://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/metadata-section-structure.html)
+
+###### `key`<sup>Required</sup> <a name="key" id="@smallcase/cdk-vpc-module.HostedZoneStack.addMetadata.parameter.key"></a>
+
+- *Type:* string
+
+---
+
+###### `value`<sup>Required</sup> <a name="value" id="@smallcase/cdk-vpc-module.HostedZoneStack.addMetadata.parameter.value"></a>
+
+- *Type:* any
+
+---
+
+##### `addStackTag` <a name="addStackTag" id="@smallcase/cdk-vpc-module.HostedZoneStack.addStackTag"></a>
+
+```typescript
+public addStackTag(tagName: string, tagValue: string): void
+```
+
+Configure a stack tag.
+
+At deploy time, CloudFormation will automatically apply all stack tags to all resources in the stack.
+
+###### `tagName`<sup>Required</sup> <a name="tagName" id="@smallcase/cdk-vpc-module.HostedZoneStack.addStackTag.parameter.tagName"></a>
+
+- *Type:* string
+
+---
+
+###### `tagValue`<sup>Required</sup> <a name="tagValue" id="@smallcase/cdk-vpc-module.HostedZoneStack.addStackTag.parameter.tagValue"></a>
+
+- *Type:* string
+
+---
+
+##### `addTransform` <a name="addTransform" id="@smallcase/cdk-vpc-module.HostedZoneStack.addTransform"></a>
+
+```typescript
+public addTransform(transform: string): void
+```
+
+Add a Transform to this stack. A Transform is a macro that AWS CloudFormation uses to process your template.
+
+Duplicate values are removed when stack is synthesized.
+
+> [https://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/transform-section-structure.html](https://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/transform-section-structure.html)
+
+*Example*
+
+```typescript
+declare const stack: Stack;
+
+stack.addTransform('AWS::Serverless-2016-10-31')
+```
+
+
+###### `transform`<sup>Required</sup> <a name="transform" id="@smallcase/cdk-vpc-module.HostedZoneStack.addTransform.parameter.transform"></a>
+
+- *Type:* string
+
+The transform to add.
+
+---
+
+##### `exportStringListValue` <a name="exportStringListValue" id="@smallcase/cdk-vpc-module.HostedZoneStack.exportStringListValue"></a>
+
+```typescript
+public exportStringListValue(exportedValue: any, options?: ExportValueOptions): string[]
+```
+
+Create a CloudFormation Export for a string list value.
+
+Returns a string list representing the corresponding `Fn.importValue()`
+expression for this Export. The export expression is automatically wrapped with an
+`Fn::Join` and the import value with an `Fn::Split`, since CloudFormation can only
+export strings. You can control the name for the export by passing the `name` option.
+
+If you don't supply a value for `name`, the value you're exporting must be
+a Resource attribute (for example: `bucket.bucketName`) and it will be
+given the same name as the automatic cross-stack reference that would be created
+if you used the attribute in another Stack.
+
+One of the uses for this method is to *remove* the relationship between
+two Stacks established by automatic cross-stack references. It will
+temporarily ensure that the CloudFormation Export still exists while you
+remove the reference from the consuming stack. After that, you can remove
+the resource and the manual export.
+
+See `exportValue` for an example of this process.
+
+###### `exportedValue`<sup>Required</sup> <a name="exportedValue" id="@smallcase/cdk-vpc-module.HostedZoneStack.exportStringListValue.parameter.exportedValue"></a>
+
+- *Type:* any
+
+---
+
+###### `options`<sup>Optional</sup> <a name="options" id="@smallcase/cdk-vpc-module.HostedZoneStack.exportStringListValue.parameter.options"></a>
+
+- *Type:* aws-cdk-lib.ExportValueOptions
+
+---
+
+##### `exportValue` <a name="exportValue" id="@smallcase/cdk-vpc-module.HostedZoneStack.exportValue"></a>
+
+```typescript
+public exportValue(exportedValue: any, options?: ExportValueOptions): string
+```
+
+Create a CloudFormation Export for a string value.
+
+Returns a string representing the corresponding `Fn.importValue()`
+expression for this Export. You can control the name for the export by
+passing the `name` option.
+
+If you don't supply a value for `name`, the value you're exporting must be
+a Resource attribute (for example: `bucket.bucketName`) and it will be
+given the same name as the automatic cross-stack reference that would be created
+if you used the attribute in another Stack.
+
+One of the uses for this method is to *remove* the relationship between
+two Stacks established by automatic cross-stack references. It will
+temporarily ensure that the CloudFormation Export still exists while you
+remove the reference from the consuming stack. After that, you can remove
+the resource and the manual export.
+
+Here is how the process works. Let's say there are two stacks,
+`producerStack` and `consumerStack`, and `producerStack` has a bucket
+called `bucket`, which is referenced by `consumerStack` (perhaps because
+an AWS Lambda Function writes into it, or something like that).
+
+It is not safe to remove `producerStack.bucket` because as the bucket is being
+deleted, `consumerStack` might still be using it.
+
+Instead, the process takes two deployments:
+
+**Deployment 1: break the relationship**:
+
+- Make sure `consumerStack` no longer references `bucket.bucketName` (maybe the consumer
+  stack now uses its own bucket, or it writes to an AWS DynamoDB table, or maybe you just
+  remove the Lambda Function altogether).
+- In the `ProducerStack` class, call `this.exportValue(this.bucket.bucketName)`. This
+  will make sure the CloudFormation Export continues to exist while the relationship
+  between the two stacks is being broken.
+- Deploy (this will effectively only change the `consumerStack`, but it's safe to deploy both).
+
+**Deployment 2: remove the bucket resource**:
+
+- You are now free to remove the `bucket` resource from `producerStack`.
+- Don't forget to remove the `exportValue()` call as well.
+- Deploy again (this time only the `producerStack` will be changed -- the bucket will be deleted).
+
+###### `exportedValue`<sup>Required</sup> <a name="exportedValue" id="@smallcase/cdk-vpc-module.HostedZoneStack.exportValue.parameter.exportedValue"></a>
+
+- *Type:* any
+
+---
+
+###### `options`<sup>Optional</sup> <a name="options" id="@smallcase/cdk-vpc-module.HostedZoneStack.exportValue.parameter.options"></a>
+
+- *Type:* aws-cdk-lib.ExportValueOptions
+
+---
+
+##### `formatArn` <a name="formatArn" id="@smallcase/cdk-vpc-module.HostedZoneStack.formatArn"></a>
+
+```typescript
+public formatArn(components: ArnComponents): string
+```
+
+Creates an ARN from components.
+
+If `partition`, `region` or `account` are not specified, the stack's
+partition, region and account will be used.
+
+If any component is the empty string, an empty string will be inserted
+into the generated ARN at the location that component corresponds to.
+
+The ARN will be formatted as follows:
+
+  arn:{partition}:{service}:{region}:{account}:{resource}{sep}{resource-name}
+
+The required ARN pieces that are omitted will be taken from the stack that
+the 'scope' is attached to. If all ARN pieces are supplied, the supplied scope
+can be 'undefined'.
+
+###### `components`<sup>Required</sup> <a name="components" id="@smallcase/cdk-vpc-module.HostedZoneStack.formatArn.parameter.components"></a>
+
+- *Type:* aws-cdk-lib.ArnComponents
+
+---
+
+##### `getLogicalId` <a name="getLogicalId" id="@smallcase/cdk-vpc-module.HostedZoneStack.getLogicalId"></a>
+
+```typescript
+public getLogicalId(element: CfnElement): string
+```
+
+Allocates a stack-unique CloudFormation-compatible logical identity for a specific resource.
+
+This method is called when a `CfnElement` is created and used to render the
+initial logical identity of resources. Logical ID renames are applied at
+this stage.
+
+This method uses the protected method `allocateLogicalId` to render the
+logical ID for an element. To modify the naming scheme, extend the `Stack`
+class and override this method.
+
+###### `element`<sup>Required</sup> <a name="element" id="@smallcase/cdk-vpc-module.HostedZoneStack.getLogicalId.parameter.element"></a>
+
+- *Type:* aws-cdk-lib.CfnElement
+
+The CloudFormation element for which a logical identity is needed.
+
+---
+
+##### `regionalFact` <a name="regionalFact" id="@smallcase/cdk-vpc-module.HostedZoneStack.regionalFact"></a>
+
+```typescript
+public regionalFact(factName: string, defaultValue?: string): string
+```
+
+Look up a fact value for the given fact for the region of this stack.
+
+Will return a definite value only if the region of the current stack is resolved.
+If not, a lookup map will be added to the stack and the lookup will be done at
+CDK deployment time.
+
+What regions will be included in the lookup map is controlled by the
+`@aws-cdk/core:target-partitions` context value: it must be set to a list
+of partitions, and only regions from the given partitions will be included.
+If no such context key is set, all regions will be included.
+
+This function is intended to be used by construct library authors. Application
+builders can rely on the abstractions offered by construct libraries and do
+not have to worry about regional facts.
+
+If `defaultValue` is not given, it is an error if the fact is unknown for
+the given region.
+
+###### `factName`<sup>Required</sup> <a name="factName" id="@smallcase/cdk-vpc-module.HostedZoneStack.regionalFact.parameter.factName"></a>
+
+- *Type:* string
+
+---
+
+###### `defaultValue`<sup>Optional</sup> <a name="defaultValue" id="@smallcase/cdk-vpc-module.HostedZoneStack.regionalFact.parameter.defaultValue"></a>
+
+- *Type:* string
+
+---
+
+##### `removeStackTag` <a name="removeStackTag" id="@smallcase/cdk-vpc-module.HostedZoneStack.removeStackTag"></a>
+
+```typescript
+public removeStackTag(tagName: string): void
+```
+
+Remove a stack tag.
+
+At deploy time, CloudFormation will automatically apply all stack tags to all resources in the stack.
+
+###### `tagName`<sup>Required</sup> <a name="tagName" id="@smallcase/cdk-vpc-module.HostedZoneStack.removeStackTag.parameter.tagName"></a>
+
+- *Type:* string
+
+---
+
+##### `renameLogicalId` <a name="renameLogicalId" id="@smallcase/cdk-vpc-module.HostedZoneStack.renameLogicalId"></a>
+
+```typescript
+public renameLogicalId(oldId: string, newId: string): void
+```
+
+Rename a generated logical identities.
+
+To modify the naming scheme strategy, extend the `Stack` class and
+override the `allocateLogicalId` method.
+
+###### `oldId`<sup>Required</sup> <a name="oldId" id="@smallcase/cdk-vpc-module.HostedZoneStack.renameLogicalId.parameter.oldId"></a>
+
+- *Type:* string
+
+---
+
+###### `newId`<sup>Required</sup> <a name="newId" id="@smallcase/cdk-vpc-module.HostedZoneStack.renameLogicalId.parameter.newId"></a>
+
+- *Type:* string
+
+---
+
+##### `reportMissingContextKey` <a name="reportMissingContextKey" id="@smallcase/cdk-vpc-module.HostedZoneStack.reportMissingContextKey"></a>
+
+```typescript
+public reportMissingContextKey(report: MissingContext): void
+```
+
+Indicate that a context key was expected.
+
+Contains instructions which will be emitted into the cloud assembly on how
+the key should be supplied.
+
+###### `report`<sup>Required</sup> <a name="report" id="@smallcase/cdk-vpc-module.HostedZoneStack.reportMissingContextKey.parameter.report"></a>
+
+- *Type:* aws-cdk-lib.cloud_assembly_schema.MissingContext
+
+The set of parameters needed to obtain the context.
+
+---
+
+##### `resolve` <a name="resolve" id="@smallcase/cdk-vpc-module.HostedZoneStack.resolve"></a>
+
+```typescript
+public resolve(obj: any): any
+```
+
+Resolve a tokenized value in the context of the current stack.
+
+###### `obj`<sup>Required</sup> <a name="obj" id="@smallcase/cdk-vpc-module.HostedZoneStack.resolve.parameter.obj"></a>
+
+- *Type:* any
+
+---
+
+##### `splitArn` <a name="splitArn" id="@smallcase/cdk-vpc-module.HostedZoneStack.splitArn"></a>
+
+```typescript
+public splitArn(arn: string, arnFormat: ArnFormat): ArnComponents
+```
+
+Splits the provided ARN into its components.
+
+Works both if 'arn' is a string like 'arn:aws:s3:::bucket',
+and a Token representing a dynamic CloudFormation expression
+(in which case the returned components will also be dynamic CloudFormation expressions,
+encoded as Tokens).
+
+###### `arn`<sup>Required</sup> <a name="arn" id="@smallcase/cdk-vpc-module.HostedZoneStack.splitArn.parameter.arn"></a>
+
+- *Type:* string
+
+the ARN to split into its components.
+
+---
+
+###### `arnFormat`<sup>Required</sup> <a name="arnFormat" id="@smallcase/cdk-vpc-module.HostedZoneStack.splitArn.parameter.arnFormat"></a>
+
+- *Type:* aws-cdk-lib.ArnFormat
+
+the expected format of 'arn' - depends on what format the service 'arn' represents uses.
+
+---
+
+##### `toJsonString` <a name="toJsonString" id="@smallcase/cdk-vpc-module.HostedZoneStack.toJsonString"></a>
+
+```typescript
+public toJsonString(obj: any, space?: number): string
+```
+
+Convert an object, potentially containing tokens, to a JSON string.
+
+###### `obj`<sup>Required</sup> <a name="obj" id="@smallcase/cdk-vpc-module.HostedZoneStack.toJsonString.parameter.obj"></a>
+
+- *Type:* any
+
+---
+
+###### `space`<sup>Optional</sup> <a name="space" id="@smallcase/cdk-vpc-module.HostedZoneStack.toJsonString.parameter.space"></a>
+
+- *Type:* number
+
+---
+
+##### `toYamlString` <a name="toYamlString" id="@smallcase/cdk-vpc-module.HostedZoneStack.toYamlString"></a>
+
+```typescript
+public toYamlString(obj: any): string
+```
+
+Convert an object, potentially containing tokens, to a YAML string.
+
+###### `obj`<sup>Required</sup> <a name="obj" id="@smallcase/cdk-vpc-module.HostedZoneStack.toYamlString.parameter.obj"></a>
+
+- *Type:* any
+
+---
+
+##### `setParameter` <a name="setParameter" id="@smallcase/cdk-vpc-module.HostedZoneStack.setParameter"></a>
+
+```typescript
+public setParameter(name: string, value: string): void
+```
+
+Assign a value to one of the nested stack parameters.
+
+###### `name`<sup>Required</sup> <a name="name" id="@smallcase/cdk-vpc-module.HostedZoneStack.setParameter.parameter.name"></a>
+
+- *Type:* string
+
+The parameter name (ID).
+
+---
+
+###### `value`<sup>Required</sup> <a name="value" id="@smallcase/cdk-vpc-module.HostedZoneStack.setParameter.parameter.value"></a>
+
+- *Type:* string
+
+The value to assign.
+
+---
+
+#### Static Functions <a name="Static Functions" id="Static Functions"></a>
+
+| **Name** | **Description** |
+| --- | --- |
+| <code><a href="#@smallcase/cdk-vpc-module.HostedZoneStack.isConstruct">isConstruct</a></code> | Checks if `x` is a construct. |
+| <code><a href="#@smallcase/cdk-vpc-module.HostedZoneStack.isStack">isStack</a></code> | Return whether the given object is a Stack. |
+| <code><a href="#@smallcase/cdk-vpc-module.HostedZoneStack.of">of</a></code> | Looks up the first stack scope in which `construct` is defined. |
+| <code><a href="#@smallcase/cdk-vpc-module.HostedZoneStack.isNestedStack">isNestedStack</a></code> | Checks if `x` is an object of type `NestedStack`. |
+
+---
+
+##### ~~`isConstruct`~~ <a name="isConstruct" id="@smallcase/cdk-vpc-module.HostedZoneStack.isConstruct"></a>
+
+```typescript
+import { HostedZoneStack } from '@smallcase/cdk-vpc-module'
+
+HostedZoneStack.isConstruct(x: any)
+```
+
+Checks if `x` is a construct.
+
+###### `x`<sup>Required</sup> <a name="x" id="@smallcase/cdk-vpc-module.HostedZoneStack.isConstruct.parameter.x"></a>
+
+- *Type:* any
+
+Any object.
+
+---
+
+##### `isStack` <a name="isStack" id="@smallcase/cdk-vpc-module.HostedZoneStack.isStack"></a>
+
+```typescript
+import { HostedZoneStack } from '@smallcase/cdk-vpc-module'
+
+HostedZoneStack.isStack(x: any)
+```
+
+Return whether the given object is a Stack.
+
+We do attribute detection since we can't reliably use 'instanceof'.
+
+###### `x`<sup>Required</sup> <a name="x" id="@smallcase/cdk-vpc-module.HostedZoneStack.isStack.parameter.x"></a>
+
+- *Type:* any
+
+---
+
+##### `of` <a name="of" id="@smallcase/cdk-vpc-module.HostedZoneStack.of"></a>
+
+```typescript
+import { HostedZoneStack } from '@smallcase/cdk-vpc-module'
+
+HostedZoneStack.of(construct: IConstruct)
+```
+
+Looks up the first stack scope in which `construct` is defined.
+
+Fails if there is no stack up the tree.
+
+###### `construct`<sup>Required</sup> <a name="construct" id="@smallcase/cdk-vpc-module.HostedZoneStack.of.parameter.construct"></a>
+
+- *Type:* constructs.IConstruct
+
+The construct to start the search from.
+
+---
+
+##### `isNestedStack` <a name="isNestedStack" id="@smallcase/cdk-vpc-module.HostedZoneStack.isNestedStack"></a>
+
+```typescript
+import { HostedZoneStack } from '@smallcase/cdk-vpc-module'
+
+HostedZoneStack.isNestedStack(x: any)
+```
+
+Checks if `x` is an object of type `NestedStack`.
+
+###### `x`<sup>Required</sup> <a name="x" id="@smallcase/cdk-vpc-module.HostedZoneStack.isNestedStack.parameter.x"></a>
+
+- *Type:* any
+
+---
+
+#### Properties <a name="Properties" id="Properties"></a>
+
+| **Name** | **Type** | **Description** |
+| --- | --- | --- |
+| <code><a href="#@smallcase/cdk-vpc-module.HostedZoneStack.property.node">node</a></code> | <code>constructs.Node</code> | The tree node. |
+| <code><a href="#@smallcase/cdk-vpc-module.HostedZoneStack.property.account">account</a></code> | <code>string</code> | The AWS account into which this stack will be deployed. |
+| <code><a href="#@smallcase/cdk-vpc-module.HostedZoneStack.property.artifactId">artifactId</a></code> | <code>string</code> | The ID of the cloud assembly artifact for this stack. |
+| <code><a href="#@smallcase/cdk-vpc-module.HostedZoneStack.property.availabilityZones">availabilityZones</a></code> | <code>string[]</code> | Returns the list of AZs that are available in the AWS environment (account/region) associated with this stack. |
+| <code><a href="#@smallcase/cdk-vpc-module.HostedZoneStack.property.bundlingRequired">bundlingRequired</a></code> | <code>boolean</code> | Indicates whether the stack requires bundling or not. |
+| <code><a href="#@smallcase/cdk-vpc-module.HostedZoneStack.property.dependencies">dependencies</a></code> | <code>aws-cdk-lib.Stack[]</code> | Return the stacks this stack depends on. |
+| <code><a href="#@smallcase/cdk-vpc-module.HostedZoneStack.property.environment">environment</a></code> | <code>string</code> | The environment coordinates in which this stack is deployed. |
+| <code><a href="#@smallcase/cdk-vpc-module.HostedZoneStack.property.nested">nested</a></code> | <code>boolean</code> | Indicates if this is a nested stack, in which case `parentStack` will include a reference to it's parent. |
+| <code><a href="#@smallcase/cdk-vpc-module.HostedZoneStack.property.notificationArns">notificationArns</a></code> | <code>string[]</code> | Returns the list of notification Amazon Resource Names (ARNs) for the current stack. |
+| <code><a href="#@smallcase/cdk-vpc-module.HostedZoneStack.property.partition">partition</a></code> | <code>string</code> | The partition in which this stack is defined. |
+| <code><a href="#@smallcase/cdk-vpc-module.HostedZoneStack.property.region">region</a></code> | <code>string</code> | The AWS region into which this stack will be deployed (e.g. `us-west-2`). |
+| <code><a href="#@smallcase/cdk-vpc-module.HostedZoneStack.property.stackId">stackId</a></code> | <code>string</code> | An attribute that represents the ID of the stack. |
+| <code><a href="#@smallcase/cdk-vpc-module.HostedZoneStack.property.stackName">stackName</a></code> | <code>string</code> | An attribute that represents the name of the nested stack. |
+| <code><a href="#@smallcase/cdk-vpc-module.HostedZoneStack.property.synthesizer">synthesizer</a></code> | <code>aws-cdk-lib.IStackSynthesizer</code> | Synthesis method for this stack. |
+| <code><a href="#@smallcase/cdk-vpc-module.HostedZoneStack.property.tags">tags</a></code> | <code>aws-cdk-lib.TagManager</code> | Tags to be applied to the stack. |
+| <code><a href="#@smallcase/cdk-vpc-module.HostedZoneStack.property.templateFile">templateFile</a></code> | <code>string</code> | The name of the CloudFormation template file emitted to the output directory during synthesis. |
+| <code><a href="#@smallcase/cdk-vpc-module.HostedZoneStack.property.templateOptions">templateOptions</a></code> | <code>aws-cdk-lib.ITemplateOptions</code> | Options for CloudFormation template (like version, transform, description). |
+| <code><a href="#@smallcase/cdk-vpc-module.HostedZoneStack.property.urlSuffix">urlSuffix</a></code> | <code>string</code> | The Amazon domain suffix for the region in which this stack is defined. |
+| <code><a href="#@smallcase/cdk-vpc-module.HostedZoneStack.property.nestedStackParent">nestedStackParent</a></code> | <code>aws-cdk-lib.Stack</code> | If this is a nested stack, returns it's parent stack. |
+| <code><a href="#@smallcase/cdk-vpc-module.HostedZoneStack.property.nestedStackResource">nestedStackResource</a></code> | <code>aws-cdk-lib.CfnResource</code> | If this is a nested stack, this represents its `AWS::CloudFormation::Stack` resource. |
+| <code><a href="#@smallcase/cdk-vpc-module.HostedZoneStack.property.terminationProtection">terminationProtection</a></code> | <code>boolean</code> | Whether termination protection is enabled for this stack. |
+| <code><a href="#@smallcase/cdk-vpc-module.HostedZoneStack.property.certificateOutputs">certificateOutputs</a></code> | <code>{[ key: string ]: aws-cdk-lib.aws_certificatemanager.Certificate}</code> | *No description.* |
+| <code><a href="#@smallcase/cdk-vpc-module.HostedZoneStack.property.hostedZoneOutputs">hostedZoneOutputs</a></code> | <code>{[ key: string ]: aws-cdk-lib.aws_route53.IHostedZone}</code> | *No description.* |
+
+---
+
+##### `node`<sup>Required</sup> <a name="node" id="@smallcase/cdk-vpc-module.HostedZoneStack.property.node"></a>
+
+```typescript
+public readonly node: Node;
+```
+
+- *Type:* constructs.Node
+
+The tree node.
+
+---
+
+##### `account`<sup>Required</sup> <a name="account" id="@smallcase/cdk-vpc-module.HostedZoneStack.property.account"></a>
+
+```typescript
+public readonly account: string;
+```
+
+- *Type:* string
+
+The AWS account into which this stack will be deployed.
+
+This value is resolved according to the following rules:
+
+1. The value provided to `env.account` when the stack is defined. This can
+   either be a concrete account (e.g. `585695031111`) or the
+   `Aws.ACCOUNT_ID` token.
+3. `Aws.ACCOUNT_ID`, which represents the CloudFormation intrinsic reference
+   `{ "Ref": "AWS::AccountId" }` encoded as a string token.
+
+Preferably, you should use the return value as an opaque string and not
+attempt to parse it to implement your logic. If you do, you must first
+check that it is a concrete value an not an unresolved token. If this
+value is an unresolved token (`Token.isUnresolved(stack.account)` returns
+`true`), this implies that the user wishes that this stack will synthesize
+into an **account-agnostic template**. In this case, your code should either
+fail (throw an error, emit a synth error using `Annotations.of(construct).addError()`) or
+implement some other account-agnostic behavior.
+
+---
+
+##### `artifactId`<sup>Required</sup> <a name="artifactId" id="@smallcase/cdk-vpc-module.HostedZoneStack.property.artifactId"></a>
+
+```typescript
+public readonly artifactId: string;
+```
+
+- *Type:* string
+
+The ID of the cloud assembly artifact for this stack.
+
+---
+
+##### `availabilityZones`<sup>Required</sup> <a name="availabilityZones" id="@smallcase/cdk-vpc-module.HostedZoneStack.property.availabilityZones"></a>
+
+```typescript
+public readonly availabilityZones: string[];
+```
+
+- *Type:* string[]
+
+Returns the list of AZs that are available in the AWS environment (account/region) associated with this stack.
+
+If the stack is environment-agnostic (either account and/or region are
+tokens), this property will return an array with 2 tokens that will resolve
+at deploy-time to the first two availability zones returned from CloudFormation's
+`Fn::GetAZs` intrinsic function.
+
+If they are not available in the context, returns a set of dummy values and
+reports them as missing, and let the CLI resolve them by calling EC2
+`DescribeAvailabilityZones` on the target environment.
+
+To specify a different strategy for selecting availability zones override this method.
+
+---
+
+##### `bundlingRequired`<sup>Required</sup> <a name="bundlingRequired" id="@smallcase/cdk-vpc-module.HostedZoneStack.property.bundlingRequired"></a>
+
+```typescript
+public readonly bundlingRequired: boolean;
+```
+
+- *Type:* boolean
+
+Indicates whether the stack requires bundling or not.
+
+---
+
+##### `dependencies`<sup>Required</sup> <a name="dependencies" id="@smallcase/cdk-vpc-module.HostedZoneStack.property.dependencies"></a>
+
+```typescript
+public readonly dependencies: Stack[];
+```
+
+- *Type:* aws-cdk-lib.Stack[]
+
+Return the stacks this stack depends on.
+
+---
+
+##### `environment`<sup>Required</sup> <a name="environment" id="@smallcase/cdk-vpc-module.HostedZoneStack.property.environment"></a>
+
+```typescript
+public readonly environment: string;
+```
+
+- *Type:* string
+
+The environment coordinates in which this stack is deployed.
+
+In the form
+`aws://account/region`. Use `stack.account` and `stack.region` to obtain
+the specific values, no need to parse.
+
+You can use this value to determine if two stacks are targeting the same
+environment.
+
+If either `stack.account` or `stack.region` are not concrete values (e.g.
+`Aws.ACCOUNT_ID` or `Aws.REGION`) the special strings `unknown-account` and/or
+`unknown-region` will be used respectively to indicate this stack is
+region/account-agnostic.
+
+---
+
+##### `nested`<sup>Required</sup> <a name="nested" id="@smallcase/cdk-vpc-module.HostedZoneStack.property.nested"></a>
+
+```typescript
+public readonly nested: boolean;
+```
+
+- *Type:* boolean
+
+Indicates if this is a nested stack, in which case `parentStack` will include a reference to it's parent.
+
+---
+
+##### `notificationArns`<sup>Required</sup> <a name="notificationArns" id="@smallcase/cdk-vpc-module.HostedZoneStack.property.notificationArns"></a>
+
+```typescript
+public readonly notificationArns: string[];
+```
+
+- *Type:* string[]
+
+Returns the list of notification Amazon Resource Names (ARNs) for the current stack.
+
+---
+
+##### `partition`<sup>Required</sup> <a name="partition" id="@smallcase/cdk-vpc-module.HostedZoneStack.property.partition"></a>
+
+```typescript
+public readonly partition: string;
+```
+
+- *Type:* string
+
+The partition in which this stack is defined.
+
+---
+
+##### `region`<sup>Required</sup> <a name="region" id="@smallcase/cdk-vpc-module.HostedZoneStack.property.region"></a>
+
+```typescript
+public readonly region: string;
+```
+
+- *Type:* string
+
+The AWS region into which this stack will be deployed (e.g. `us-west-2`).
+
+This value is resolved according to the following rules:
+
+1. The value provided to `env.region` when the stack is defined. This can
+   either be a concrete region (e.g. `us-west-2`) or the `Aws.REGION`
+   token.
+3. `Aws.REGION`, which is represents the CloudFormation intrinsic reference
+   `{ "Ref": "AWS::Region" }` encoded as a string token.
+
+Preferably, you should use the return value as an opaque string and not
+attempt to parse it to implement your logic. If you do, you must first
+check that it is a concrete value an not an unresolved token. If this
+value is an unresolved token (`Token.isUnresolved(stack.region)` returns
+`true`), this implies that the user wishes that this stack will synthesize
+into a **region-agnostic template**. In this case, your code should either
+fail (throw an error, emit a synth error using `Annotations.of(construct).addError()`) or
+implement some other region-agnostic behavior.
+
+---
+
+##### `stackId`<sup>Required</sup> <a name="stackId" id="@smallcase/cdk-vpc-module.HostedZoneStack.property.stackId"></a>
+
+```typescript
+public readonly stackId: string;
+```
+
+- *Type:* string
+
+An attribute that represents the ID of the stack.
+
+This is a context aware attribute:
+- If this is referenced from the parent stack, it will return `{ "Ref": "LogicalIdOfNestedStackResource" }`.
+- If this is referenced from the context of the nested stack, it will return `{ "Ref": "AWS::StackId" }`
+
+Example value: `arn:aws:cloudformation:us-east-2:123456789012:stack/mystack-mynestedstack-sggfrhxhum7w/f449b250-b969-11e0-a185-5081d0136786`
+
+---
+
+##### `stackName`<sup>Required</sup> <a name="stackName" id="@smallcase/cdk-vpc-module.HostedZoneStack.property.stackName"></a>
+
+```typescript
+public readonly stackName: string;
+```
+
+- *Type:* string
+
+An attribute that represents the name of the nested stack.
+
+This is a context aware attribute:
+- If this is referenced from the parent stack, it will return a token that parses the name from the stack ID.
+- If this is referenced from the context of the nested stack, it will return `{ "Ref": "AWS::StackName" }`
+
+Example value: `mystack-mynestedstack-sggfrhxhum7w`
+
+---
+
+##### `synthesizer`<sup>Required</sup> <a name="synthesizer" id="@smallcase/cdk-vpc-module.HostedZoneStack.property.synthesizer"></a>
+
+```typescript
+public readonly synthesizer: IStackSynthesizer;
+```
+
+- *Type:* aws-cdk-lib.IStackSynthesizer
+
+Synthesis method for this stack.
+
+---
+
+##### `tags`<sup>Required</sup> <a name="tags" id="@smallcase/cdk-vpc-module.HostedZoneStack.property.tags"></a>
+
+```typescript
+public readonly tags: TagManager;
+```
+
+- *Type:* aws-cdk-lib.TagManager
+
+Tags to be applied to the stack.
+
+---
+
+##### `templateFile`<sup>Required</sup> <a name="templateFile" id="@smallcase/cdk-vpc-module.HostedZoneStack.property.templateFile"></a>
+
+```typescript
+public readonly templateFile: string;
+```
+
+- *Type:* string
+
+The name of the CloudFormation template file emitted to the output directory during synthesis.
+
+Example value: `MyStack.template.json`
+
+---
+
+##### `templateOptions`<sup>Required</sup> <a name="templateOptions" id="@smallcase/cdk-vpc-module.HostedZoneStack.property.templateOptions"></a>
+
+```typescript
+public readonly templateOptions: ITemplateOptions;
+```
+
+- *Type:* aws-cdk-lib.ITemplateOptions
+
+Options for CloudFormation template (like version, transform, description).
+
+---
+
+##### `urlSuffix`<sup>Required</sup> <a name="urlSuffix" id="@smallcase/cdk-vpc-module.HostedZoneStack.property.urlSuffix"></a>
+
+```typescript
+public readonly urlSuffix: string;
+```
+
+- *Type:* string
+
+The Amazon domain suffix for the region in which this stack is defined.
+
+---
+
+##### `nestedStackParent`<sup>Optional</sup> <a name="nestedStackParent" id="@smallcase/cdk-vpc-module.HostedZoneStack.property.nestedStackParent"></a>
+
+```typescript
+public readonly nestedStackParent: Stack;
+```
+
+- *Type:* aws-cdk-lib.Stack
+
+If this is a nested stack, returns it's parent stack.
+
+---
+
+##### `nestedStackResource`<sup>Optional</sup> <a name="nestedStackResource" id="@smallcase/cdk-vpc-module.HostedZoneStack.property.nestedStackResource"></a>
+
+```typescript
+public readonly nestedStackResource: CfnResource;
+```
+
+- *Type:* aws-cdk-lib.CfnResource
+
+If this is a nested stack, this represents its `AWS::CloudFormation::Stack` resource.
+
+`undefined` for top-level (non-nested) stacks.
+
+---
+
+##### `terminationProtection`<sup>Required</sup> <a name="terminationProtection" id="@smallcase/cdk-vpc-module.HostedZoneStack.property.terminationProtection"></a>
+
+```typescript
+public readonly terminationProtection: boolean;
+```
+
+- *Type:* boolean
+
+Whether termination protection is enabled for this stack.
+
+---
+
+##### `certificateOutputs`<sup>Required</sup> <a name="certificateOutputs" id="@smallcase/cdk-vpc-module.HostedZoneStack.property.certificateOutputs"></a>
+
+```typescript
+public readonly certificateOutputs: {[ key: string ]: Certificate};
+```
+
+- *Type:* {[ key: string ]: aws-cdk-lib.aws_certificatemanager.Certificate}
+
+---
+
+##### `hostedZoneOutputs`<sup>Required</sup> <a name="hostedZoneOutputs" id="@smallcase/cdk-vpc-module.HostedZoneStack.property.hostedZoneOutputs"></a>
+
+```typescript
+public readonly hostedZoneOutputs: {[ key: string ]: IHostedZone};
+```
+
+- *Type:* {[ key: string ]: aws-cdk-lib.aws_route53.IHostedZone}
+
+---
+
+
 ### Network <a name="Network" id="@smallcase/cdk-vpc-module.Network"></a>
 
 #### Initializers <a name="Initializers" id="@smallcase/cdk-vpc-module.Network.Initializer"></a>
@@ -1277,6 +2249,183 @@ public readonly routerId: string;
 ```
 
 - *Type:* string
+
+---
+
+### HostedZoneConfig <a name="HostedZoneConfig" id="@smallcase/cdk-vpc-module.HostedZoneConfig"></a>
+
+#### Initializer <a name="Initializer" id="@smallcase/cdk-vpc-module.HostedZoneConfig.Initializer"></a>
+
+```typescript
+import { HostedZoneConfig } from '@smallcase/cdk-vpc-module'
+
+const hostedZoneConfig: HostedZoneConfig = { ... }
+```
+
+#### Properties <a name="Properties" id="Properties"></a>
+
+| **Name** | **Type** | **Description** |
+| --- | --- | --- |
+| <code><a href="#@smallcase/cdk-vpc-module.HostedZoneConfig.property.publicZone">publicZone</a></code> | <code>boolean</code> | *No description.* |
+| <code><a href="#@smallcase/cdk-vpc-module.HostedZoneConfig.property.zoneName">zoneName</a></code> | <code>string</code> | *No description.* |
+| <code><a href="#@smallcase/cdk-vpc-module.HostedZoneConfig.property.createAcmCertificate">createAcmCertificate</a></code> | <code>boolean</code> | *No description.* |
+
+---
+
+##### `publicZone`<sup>Required</sup> <a name="publicZone" id="@smallcase/cdk-vpc-module.HostedZoneConfig.property.publicZone"></a>
+
+```typescript
+public readonly publicZone: boolean;
+```
+
+- *Type:* boolean
+
+---
+
+##### `zoneName`<sup>Required</sup> <a name="zoneName" id="@smallcase/cdk-vpc-module.HostedZoneConfig.property.zoneName"></a>
+
+```typescript
+public readonly zoneName: string;
+```
+
+- *Type:* string
+
+---
+
+##### `createAcmCertificate`<sup>Optional</sup> <a name="createAcmCertificate" id="@smallcase/cdk-vpc-module.HostedZoneConfig.property.createAcmCertificate"></a>
+
+```typescript
+public readonly createAcmCertificate: boolean;
+```
+
+- *Type:* boolean
+
+---
+
+### HostedZoneStackProps <a name="HostedZoneStackProps" id="@smallcase/cdk-vpc-module.HostedZoneStackProps"></a>
+
+#### Initializer <a name="Initializer" id="@smallcase/cdk-vpc-module.HostedZoneStackProps.Initializer"></a>
+
+```typescript
+import { HostedZoneStackProps } from '@smallcase/cdk-vpc-module'
+
+const hostedZoneStackProps: HostedZoneStackProps = { ... }
+```
+
+#### Properties <a name="Properties" id="Properties"></a>
+
+| **Name** | **Type** | **Description** |
+| --- | --- | --- |
+| <code><a href="#@smallcase/cdk-vpc-module.HostedZoneStackProps.property.description">description</a></code> | <code>string</code> | A description of the stack. |
+| <code><a href="#@smallcase/cdk-vpc-module.HostedZoneStackProps.property.notificationArns">notificationArns</a></code> | <code>string[]</code> | The Simple Notification Service (SNS) topics to publish stack related events. |
+| <code><a href="#@smallcase/cdk-vpc-module.HostedZoneStackProps.property.parameters">parameters</a></code> | <code>{[ key: string ]: string}</code> | The set value pairs that represent the parameters passed to CloudFormation when this nested stack is created. |
+| <code><a href="#@smallcase/cdk-vpc-module.HostedZoneStackProps.property.removalPolicy">removalPolicy</a></code> | <code>aws-cdk-lib.RemovalPolicy</code> | Policy to apply when the nested stack is removed. |
+| <code><a href="#@smallcase/cdk-vpc-module.HostedZoneStackProps.property.timeout">timeout</a></code> | <code>aws-cdk-lib.Duration</code> | The length of time that CloudFormation waits for the nested stack to reach the CREATE_COMPLETE state. |
+| <code><a href="#@smallcase/cdk-vpc-module.HostedZoneStackProps.property.hostedZones">hostedZones</a></code> | <code><a href="#@smallcase/cdk-vpc-module.HostedZoneConfig">HostedZoneConfig</a>[]</code> | *No description.* |
+| <code><a href="#@smallcase/cdk-vpc-module.HostedZoneStackProps.property.vpc">vpc</a></code> | <code>aws-cdk-lib.aws_ec2.IVpc</code> | *No description.* |
+
+---
+
+##### `description`<sup>Optional</sup> <a name="description" id="@smallcase/cdk-vpc-module.HostedZoneStackProps.property.description"></a>
+
+```typescript
+public readonly description: string;
+```
+
+- *Type:* string
+- *Default:* No description.
+
+A description of the stack.
+
+---
+
+##### `notificationArns`<sup>Optional</sup> <a name="notificationArns" id="@smallcase/cdk-vpc-module.HostedZoneStackProps.property.notificationArns"></a>
+
+```typescript
+public readonly notificationArns: string[];
+```
+
+- *Type:* string[]
+- *Default:* notifications are not sent for this stack.
+
+The Simple Notification Service (SNS) topics to publish stack related events.
+
+---
+
+##### `parameters`<sup>Optional</sup> <a name="parameters" id="@smallcase/cdk-vpc-module.HostedZoneStackProps.property.parameters"></a>
+
+```typescript
+public readonly parameters: {[ key: string ]: string};
+```
+
+- *Type:* {[ key: string ]: string}
+- *Default:* no user-defined parameters are passed to the nested stack
+
+The set value pairs that represent the parameters passed to CloudFormation when this nested stack is created.
+
+Each parameter has a name corresponding
+to a parameter defined in the embedded template and a value representing
+the value that you want to set for the parameter.
+
+The nested stack construct will automatically synthesize parameters in order
+to bind references from the parent stack(s) into the nested stack.
+
+---
+
+##### `removalPolicy`<sup>Optional</sup> <a name="removalPolicy" id="@smallcase/cdk-vpc-module.HostedZoneStackProps.property.removalPolicy"></a>
+
+```typescript
+public readonly removalPolicy: RemovalPolicy;
+```
+
+- *Type:* aws-cdk-lib.RemovalPolicy
+- *Default:* RemovalPolicy.DESTROY
+
+Policy to apply when the nested stack is removed.
+
+The default is `Destroy`, because all Removal Policies of resources inside the
+Nested Stack should already have been set correctly. You normally should
+not need to set this value.
+
+---
+
+##### `timeout`<sup>Optional</sup> <a name="timeout" id="@smallcase/cdk-vpc-module.HostedZoneStackProps.property.timeout"></a>
+
+```typescript
+public readonly timeout: Duration;
+```
+
+- *Type:* aws-cdk-lib.Duration
+- *Default:* no timeout
+
+The length of time that CloudFormation waits for the nested stack to reach the CREATE_COMPLETE state.
+
+When CloudFormation detects that the nested stack has reached the
+CREATE_COMPLETE state, it marks the nested stack resource as
+CREATE_COMPLETE in the parent stack and resumes creating the parent stack.
+If the timeout period expires before the nested stack reaches
+CREATE_COMPLETE, CloudFormation marks the nested stack as failed and rolls
+back both the nested stack and parent stack.
+
+---
+
+##### `hostedZones`<sup>Required</sup> <a name="hostedZones" id="@smallcase/cdk-vpc-module.HostedZoneStackProps.property.hostedZones"></a>
+
+```typescript
+public readonly hostedZones: HostedZoneConfig[];
+```
+
+- *Type:* <a href="#@smallcase/cdk-vpc-module.HostedZoneConfig">HostedZoneConfig</a>[]
+
+---
+
+##### `vpc`<sup>Optional</sup> <a name="vpc" id="@smallcase/cdk-vpc-module.HostedZoneStackProps.property.vpc"></a>
+
+```typescript
+public readonly vpc: IVpc;
+```
+
+- *Type:* aws-cdk-lib.aws_ec2.IVpc
 
 ---
 

--- a/README.md
+++ b/README.md
@@ -7,6 +7,7 @@ cdk-vpc-module construct library is an open-source extension of the AWS Cloud De
 - :white_check_mark: VPC Peering with  route table entry
 - :white_check_mark: Configurable NACL as per subnet group
 - :white_check_mark: NATGateway as per availabilityZones
+- :white_check_mark: Public/private Route 53 hosted zones with optional public ACM certificate
 
 
 Using cdk a vpc can be deployed using the following sample code snippet:
@@ -194,6 +195,32 @@ new VPCStack(app, 'TEST', {
 app.synth();
 ```
 Please refer [here](/API.md) to check how to use individual resource constructs.
+
+## Route 53 hosted zones
+
+Hosted zones are modeled separately from the `Network` construct. For private
+hosted zones, pass the VPC from the network stack and the zone is associated
+with that VPC automatically. ACM certificate creation is supported only for
+public hosted zones and creates a certificate for both `<host>` and `*.<host>`.
+
+```typescript
+import { HostedZoneStack } from '@smallcase/cdk-vpc-module/lib/constructs/hosted-zone';
+
+const hostedZones = new HostedZoneStack(this, 'HostedZones', {
+  vpc: network.vpc,
+  hostedZones: [
+    {
+      zoneName: 'example.smallcase.com',
+      publicZone: true,
+      createAcmCertificate: true,
+    },
+    {
+      zoneName: 'internal.example.smallcase.com',
+      publicZone: false,
+    },
+  ],
+});
+```
 
 ## :clapper: Quick Start
 

--- a/src/constructs/hosted-zone.ts
+++ b/src/constructs/hosted-zone.ts
@@ -6,6 +6,7 @@ import {
   Fn,
   NestedStack,
   NestedStackProps,
+  Tags,
 } from 'aws-cdk-lib';
 import { Construct } from 'constructs';
 
@@ -13,38 +14,39 @@ export interface HostedZoneConfig {
   readonly zoneName: string;
   readonly publicZone: boolean;
   readonly createAcmCertificate?: boolean;
+  readonly certificateValidationZoneName?: string;
+  readonly tags?: Record<string, string>;
 }
 
 export interface HostedZoneStackProps extends NestedStackProps {
   readonly hostedZones: HostedZoneConfig[];
   readonly vpc?: ec2.IVpc;
+  readonly hostedZoneTags?: Record<string, string>;
 }
 
 export class HostedZoneStack extends NestedStack {
   public readonly hostedZoneOutputs: { [key: string]: route53.IHostedZone } = {};
   public readonly certificateOutputs: { [key: string]: acm.Certificate } = {};
+  private readonly publicValidationHostedZones: { [key: string]: route53.IHostedZone } = {};
 
   constructor(scope: Construct, id: string, props: HostedZoneStackProps) {
     super(scope, id, props);
 
     props.hostedZones.forEach((hostedZoneConfig) => {
-      this.addHostedZone(hostedZoneConfig, props.vpc);
+      this.addHostedZone(hostedZoneConfig, props.vpc, props.hostedZoneTags);
+    });
+    props.hostedZones.forEach((hostedZoneConfig) => {
+      this.addCertificate(hostedZoneConfig, props.hostedZoneTags);
     });
   }
 
-  private addHostedZone(hostedZoneConfig: HostedZoneConfig, vpc?: ec2.IVpc) {
+  private addHostedZone(hostedZoneConfig: HostedZoneConfig, vpc?: ec2.IVpc, hostedZoneTags?: Record<string, string>) {
     const idPrefix = hostedZoneConfig.zoneName.replace(/[^A-Za-z0-9]/g, '');
     if (!hostedZoneConfig.publicZone && !vpc) {
       throw new Error(
         `Private hosted zone requires a VPC association: ${hostedZoneConfig.zoneName}`,
       );
     }
-    if (!hostedZoneConfig.publicZone && hostedZoneConfig.createAcmCertificate) {
-      throw new Error(
-        `ACM certificate generation is supported only for public hosted zones: ${hostedZoneConfig.zoneName}`,
-      );
-    }
-
     const hostedZone = hostedZoneConfig.publicZone
       ? new route53.PublicHostedZone(this, `${idPrefix}PublicHostedZone`, {
         zoneName: hostedZoneConfig.zoneName,
@@ -55,28 +57,76 @@ export class HostedZoneStack extends NestedStack {
       });
 
     this.hostedZoneOutputs[hostedZoneConfig.zoneName] = hostedZone;
+    this.applyTags(hostedZone, this.resolveTags(hostedZoneTags, hostedZoneConfig.tags));
     new CfnOutput(this, `${idPrefix}HostedZoneId`, {
       value: hostedZone.hostedZoneId,
       description: `Hosted zone ID for ${hostedZoneConfig.zoneName}`,
     });
     if (hostedZoneConfig.publicZone) {
+      this.publicValidationHostedZones[hostedZoneConfig.zoneName] = hostedZone;
       new CfnOutput(this, `${idPrefix}NameServers`, {
         value: Fn.join(',', hostedZone.hostedZoneNameServers ?? []),
         description: `Name servers for ${hostedZoneConfig.zoneName}`,
       });
     }
+  }
 
+  private addCertificate(hostedZoneConfig: HostedZoneConfig, hostedZoneTags?: Record<string, string>) {
     if (hostedZoneConfig.createAcmCertificate) {
+      const idPrefix = hostedZoneConfig.zoneName.replace(/[^A-Za-z0-9]/g, '');
+      const validationHostedZone = this.getCertificateValidationHostedZone(hostedZoneConfig);
       const certificate = new acm.Certificate(this, `${idPrefix}Certificate`, {
         domainName: hostedZoneConfig.zoneName,
         subjectAlternativeNames: [`*.${hostedZoneConfig.zoneName}`],
-        validation: acm.CertificateValidation.fromDns(hostedZone),
+        validation: acm.CertificateValidation.fromDns(validationHostedZone),
       });
+      this.applyTags(certificate, this.resolveTags(hostedZoneTags, hostedZoneConfig.tags));
       this.certificateOutputs[hostedZoneConfig.zoneName] = certificate;
       new CfnOutput(this, `${idPrefix}CertificateArn`, {
         value: certificate.certificateArn,
         description: `ACM certificate ARN for ${hostedZoneConfig.zoneName}`,
       });
     }
+  }
+
+  private getCertificateValidationHostedZone(hostedZoneConfig: HostedZoneConfig): route53.IHostedZone {
+    const validationZoneName = hostedZoneConfig.publicZone
+      ? hostedZoneConfig.zoneName
+      : hostedZoneConfig.certificateValidationZoneName;
+
+    if (!validationZoneName) {
+      throw new Error(
+        `ACM certificate generation for private hosted zone requires certificateValidationZoneName: ${hostedZoneConfig.zoneName}`,
+      );
+    }
+
+    if (this.publicValidationHostedZones[validationZoneName]) {
+      return this.publicValidationHostedZones[validationZoneName];
+    }
+
+    const idPrefix = validationZoneName.replace(/[^A-Za-z0-9]/g, '');
+    const validationHostedZone = route53.HostedZone.fromLookup(this, `${idPrefix}CertificateValidationHostedZone`, {
+      domainName: validationZoneName,
+      privateZone: false,
+    });
+    this.publicValidationHostedZones[validationZoneName] = validationHostedZone;
+    return validationHostedZone;
+  }
+
+  private applyTags(scope: Construct, tags?: Record<string, string>) {
+    if (!tags) {
+      return;
+    }
+
+    Object.entries(tags).forEach(([key, value]) => {
+      Tags.of(scope).add(key, value);
+    });
+  }
+
+  private resolveTags(hostedZoneTags?: Record<string, string>, hostedZoneConfigTags?: Record<string, string>) {
+    return {
+      ...hostedZoneTags,
+      ...hostedZoneConfigTags,
+    };
   }
 }

--- a/src/constructs/hosted-zone.ts
+++ b/src/constructs/hosted-zone.ts
@@ -1,0 +1,82 @@
+import {
+  aws_certificatemanager as acm,
+  aws_ec2 as ec2,
+  aws_route53 as route53,
+  CfnOutput,
+  Fn,
+  NestedStack,
+  NestedStackProps,
+} from 'aws-cdk-lib';
+import { Construct } from 'constructs';
+
+export interface HostedZoneConfig {
+  readonly zoneName: string;
+  readonly publicZone: boolean;
+  readonly createAcmCertificate?: boolean;
+}
+
+export interface HostedZoneStackProps extends NestedStackProps {
+  readonly hostedZones: HostedZoneConfig[];
+  readonly vpc?: ec2.IVpc;
+}
+
+export class HostedZoneStack extends NestedStack {
+  public readonly hostedZoneOutputs: { [key: string]: route53.IHostedZone } = {};
+  public readonly certificateOutputs: { [key: string]: acm.Certificate } = {};
+
+  constructor(scope: Construct, id: string, props: HostedZoneStackProps) {
+    super(scope, id, props);
+
+    props.hostedZones.forEach((hostedZoneConfig) => {
+      this.addHostedZone(hostedZoneConfig, props.vpc);
+    });
+  }
+
+  private addHostedZone(hostedZoneConfig: HostedZoneConfig, vpc?: ec2.IVpc) {
+    const idPrefix = hostedZoneConfig.zoneName.replace(/[^A-Za-z0-9]/g, '');
+    if (!hostedZoneConfig.publicZone && !vpc) {
+      throw new Error(
+        `Private hosted zone requires a VPC association: ${hostedZoneConfig.zoneName}`,
+      );
+    }
+    if (!hostedZoneConfig.publicZone && hostedZoneConfig.createAcmCertificate) {
+      throw new Error(
+        `ACM certificate generation is supported only for public hosted zones: ${hostedZoneConfig.zoneName}`,
+      );
+    }
+
+    const hostedZone = hostedZoneConfig.publicZone
+      ? new route53.PublicHostedZone(this, `${idPrefix}PublicHostedZone`, {
+        zoneName: hostedZoneConfig.zoneName,
+      })
+      : new route53.PrivateHostedZone(this, `${idPrefix}PrivateHostedZone`, {
+        zoneName: hostedZoneConfig.zoneName,
+        vpc: vpc!,
+      });
+
+    this.hostedZoneOutputs[hostedZoneConfig.zoneName] = hostedZone;
+    new CfnOutput(this, `${idPrefix}HostedZoneId`, {
+      value: hostedZone.hostedZoneId,
+      description: `Hosted zone ID for ${hostedZoneConfig.zoneName}`,
+    });
+    if (hostedZoneConfig.publicZone) {
+      new CfnOutput(this, `${idPrefix}NameServers`, {
+        value: Fn.join(',', hostedZone.hostedZoneNameServers ?? []),
+        description: `Name servers for ${hostedZoneConfig.zoneName}`,
+      });
+    }
+
+    if (hostedZoneConfig.createAcmCertificate) {
+      const certificate = new acm.Certificate(this, `${idPrefix}Certificate`, {
+        domainName: hostedZoneConfig.zoneName,
+        subjectAlternativeNames: [`*.${hostedZoneConfig.zoneName}`],
+        validation: acm.CertificateValidation.fromDns(hostedZone),
+      });
+      this.certificateOutputs[hostedZoneConfig.zoneName] = certificate;
+      new CfnOutput(this, `${idPrefix}CertificateArn`, {
+        value: certificate.certificateArn,
+        description: `ACM certificate ARN for ${hostedZoneConfig.zoneName}`,
+      });
+    }
+  }
+}

--- a/src/constructs/network.ts
+++ b/src/constructs/network.ts
@@ -7,6 +7,7 @@ import {
 } from 'aws-cdk-lib';
 import { AwsCustomResource, AwsCustomResourcePolicy, PhysicalResourceId } from 'aws-cdk-lib/custom-resources';
 import { Construct } from 'constructs';
+import { HostedZoneConfig, HostedZoneStack } from './hosted-zone';
 import { SubnetStack } from './subnet-stack';
 import { VpcEndpointServiceNestedStack, VpcEndpontServiceConfig } from './vpc-endpoint-service';
 import { ObjToStrMap } from '../utils/common';
@@ -77,6 +78,7 @@ export interface VPCProps {
   readonly vpcEndpoints?: VpcEndpointConfig[]; // List of VPC endpoints to configure
   readonly natEipAllocationIds?: string[];
   readonly subnets: ISubnetsProps[];
+  readonly hostedZones?: HostedZoneConfig[];
   readonly vpcEndpointServices?: VpcEndpontServiceConfig[]; // List of VPC endpoint Service to configure
   readonly useNestedStacks?: boolean;
 }
@@ -124,6 +126,7 @@ export class Network extends Construct {
   public readonly vpc!: ec2.Vpc;
   public readonly securityGroupOutputs: { [key: string]: ec2.SecurityGroup } = {}; // Store Security Group outputs
   public readonly endpointOutputs: { [key: string]: ec2.InterfaceVpcEndpoint | ec2.GatewayVpcEndpoint } = {}; // Store Endpoint outputs
+  public readonly hostedZoneStack?: HostedZoneStack;
   private peeringConnectionIds: PeeringConnectionInternalType = {};
   public readonly natProvider!: ec2.NatProvider;
   constructor(scope: Construct, id: string, props: VPCProps) {
@@ -204,6 +207,12 @@ export class Network extends Construct {
       });
     }
     new CfnOutput(this, 'VpcId', { value: this.vpc.vpcId });
+    if (props.hostedZones) {
+      this.hostedZoneStack = new HostedZoneStack(this, 'HostedZones', {
+        hostedZones: props.hostedZones,
+        vpc: this.vpc,
+      });
+    }
     // Add VPC endpoints if specified in the props
     if (props?.vpcEndpoints) {
       for (const endpointConfig of props.vpcEndpoints) {

--- a/src/constructs/network.ts
+++ b/src/constructs/network.ts
@@ -79,6 +79,7 @@ export interface VPCProps {
   readonly natEipAllocationIds?: string[];
   readonly subnets: ISubnetsProps[];
   readonly hostedZones?: HostedZoneConfig[];
+  readonly hostedZoneTags?: Record<string, string>;
   readonly vpcEndpointServices?: VpcEndpontServiceConfig[]; // List of VPC endpoint Service to configure
   readonly useNestedStacks?: boolean;
 }
@@ -210,6 +211,7 @@ export class Network extends Construct {
     if (props.hostedZones) {
       this.hostedZoneStack = new HostedZoneStack(this, 'HostedZones', {
         hostedZones: props.hostedZones,
+        hostedZoneTags: props.hostedZoneTags,
         vpc: this.vpc,
       });
     }

--- a/src/constructs/network.ts
+++ b/src/constructs/network.ts
@@ -1,4 +1,10 @@
-import { aws_ec2 as ec2, CfnOutput, Tags, aws_iam as iam, Stack } from 'aws-cdk-lib';
+import {
+  aws_ec2 as ec2,
+  CfnOutput,
+  Tags,
+  aws_iam as iam,
+  Stack,
+} from 'aws-cdk-lib';
 import { AwsCustomResource, AwsCustomResourcePolicy, PhysicalResourceId } from 'aws-cdk-lib/custom-resources';
 import { Construct } from 'constructs';
 import { SubnetStack } from './subnet-stack';
@@ -500,5 +506,3 @@ export class Network extends Construct {
     });
   }
 }
-
-

--- a/src/index.ts
+++ b/src/index.ts
@@ -1,2 +1,3 @@
+export * from './constructs/hosted-zone';
 export * from './constructs/network';
 export * from './constructs/vpc-endpoint-service';


### PR DESCRIPTION
## Summary
- add standalone HostedZoneStack for Route 53 hosted zones
- support public/private hosted zones from config
- associate private hosted zones with the provided VPC
- optionally create a public ACM certificate for apex and wildcard hostnames

## Validation
- yarn build